### PR TITLE
feat: added -data & -o flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project is in a very early stage. Things might break !
 ## Usage
 
 For simplicity, everything is output on `stdout`. To write the result in a
-file, use shell redirection.
+file, use shell redirection or the `-o` flag.
 
 If a variable is not found and the strict mode is disabled (default disabled),
 each missing value will be replaced with an empty string.
@@ -27,11 +27,23 @@ USAGE: tmpl [OPTIONS] INPUT
 INPUT is a template file or '-' for stdin
 
 OPTIONS:
+  -data string
+        JSON data as a string or reference to a file ('@file') [DO NOT USE]
   -f value
-        load variables from JSON/TOML/YAML files (format: file path)
-  -s    exit on any error during template processing (default false)
+        Load variables from one or more JSON/TOML/YAML files (format: file path)
+  -o string
+        Output file path, uses stdout if not set (format: file path)
+  -s    Strict mode. Raise errors if variables are missing (default: false)
   -v value
-        use one or more variables from the command line (format: name=value)
+        Use one or more variables from the command line (format: name=value)
+
+The '-data' flag is for compatibility with https://github.com/benbjohnson/tmpl
+and its use is not recommended.
+
+When 'data' is used the '-f' and '-v' args are ignored, the INPUT file is
+expected to have the '.tmpl' suffix and if the '-o' flag is not used the output
+is written to the INPUT path removing the '.tmpl' suffix (if INPUT is '-' the
+output goes to stdout).
 ```
 
 - `stdin` and environment variables.
@@ -59,3 +71,11 @@ $ tmpl -f ./stores/data.yaml ./inputs/sample.txt.tmpl
 ## Configuration
 
 No configuration needed. Everything is done on the command line.
+
+## About the data flag
+
+The `-data` flag has been included to be able the replace the `tmpl` binary on
+the Debian distribution.
+
+It was built from the https://github.com/benbjohnson/tmpl repository and the
+idea is that it should not be used, as it is not really needed.

--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 

--- a/cli.go
+++ b/cli.go
@@ -24,6 +24,8 @@ var (
 	VarsList  stringsArray
 	FilesList stringsArray
 	Strict    bool
+	DataVar   string
+	OutPath   string
 )
 
 func initFlags() {
@@ -45,6 +47,20 @@ func initFlags() {
 		"Strict mode. Raise errors if variables are missing (default: false)",
 	)
 
+	flag.StringVar(
+		&DataVar,
+		"data",
+		"",
+		"JSON data as a string or reference to a file ('@file') [DO NOT USE]",
+	)
+
+	flag.StringVar(
+		&OutPath,
+		"o",
+		"",
+		"Output file path, uses stdout if not set (format: file path)",
+	)
+
 	flag.Usage = func() {
 		log.Printf(
 			`USAGE: %s [OPTIONS] INPUT
@@ -56,6 +72,16 @@ OPTIONS:
 			os.Args[0],
 		)
 		flag.PrintDefaults()
+		log.Printf(`
+The '-data' flag is for compatibility with https://github.com/benbjohnson/tmpl
+and its use is not recommended.
+
+When 'data' is used the '-f' and '-v' args are ignored, the INPUT file is
+expected to have the '.tmpl' suffix and if the '-o' flag is not used the output
+is written to the INPUT path removing the '.tmpl' suffix (if INPUT is '-' the
+output goes to stdout).
+`,
+		)
 	}
 
 	flag.Parse()

--- a/main.go
+++ b/main.go
@@ -6,9 +6,14 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
+const cdataExtension = ".tmpl"
+
 func main() {
+	var outputPath string
+
 	log.SetFlags(0)
 	log.SetPrefix(fmt.Sprintf("%s: ", os.Args[0]))
 
@@ -28,9 +33,28 @@ func main() {
 		inputsDir = filepath.Dir(inputAbs)
 	}
 
+	outputPath = OutPath
+	if outputPath == "" && DataVar != "" && input != "-" {
+		if !strings.HasSuffix(input, cdataExtension) {
+			err := fmt.Errorf("path must have %s extension: %s", cdataExtension, input)
+			log.Fatal(err)
+		}
+		outputPath = strings.TrimSuffix(input, cdataExtension)
+	}
+
 	output, err := executeTemplateFile(input)
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Print(output)
+
+	if outputPath == "" {
+		fmt.Print(output)
+	} else {
+		fi, err := os.Stat(input)
+		if err == nil {
+			os.WriteFile(outputPath, []byte(output), fi.Mode())
+		} else {
+			log.Fatal(err)
+		}
+	}
 }

--- a/template.go
+++ b/template.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"text/template"
@@ -31,11 +31,16 @@ func executeTemplateFile(input string) (string, error) {
 		tmpl.Option("missingkey=error")
 	}
 
-	if len(ctx) == 0 {
+	if len(ctx) == 0 && cdata == nil {
 		loadContext()
 	}
 
-	err = tmpl.Execute(&outputBytes, ctx)
+	if cdata == nil {
+		err = tmpl.Execute(&outputBytes, ctx)
+	} else {
+		err = tmpl.Execute(&outputBytes, cdata)
+	}
+
 	if err != nil {
 		return "", err
 	}
@@ -51,9 +56,9 @@ func readInput(input string) ([]byte, error) {
 		inputBytes []byte
 	)
 	if input == "-" {
-		inputBytes, err = ioutil.ReadAll(os.Stdin)
+		inputBytes, err = io.ReadAll(os.Stdin)
 	} else {
-		inputBytes, err = ioutil.ReadFile(input)
+		inputBytes, err = os.ReadFile(input)
 	}
 	return inputBytes, err
 }


### PR DESCRIPTION
This patch is to add compatibility with the `tmpl` command available in Debian (see issue #2).

If you add it I believe we are 100% compatible with the tool already uploaded to the archive and I'll be able to replace it with your version.

Thanks in advance.