### PR TITLE
fix: exit on err for getFileVariables

### DIFF
--- a/context.go
+++ b/context.go
@@ -30,8 +30,7 @@ func getFileVariables(file string) map[string]interface{} {
 
 	bytes, err := ioutil.ReadFile(file)
 	if err != nil {
-		log.Printf("unable to read file\n%v\n", err)
-		return vars
+		log.Fatalf("unable to read file\n%v\n", err)
 	}
 
 	if strings.HasSuffix(file, ".json") {
@@ -44,7 +43,7 @@ func getFileVariables(file string) map[string]interface{} {
 		err = fmt.Errorf("bad file type: %s", file)
 	}
 	if err != nil {
-		log.Printf("unable to load data\n%v\n", err)
+		log.Fatalf("unable to load data\n%v\n", err)
 	}
 	return vars
 }


### PR DESCRIPTION
I'm using `tmpl` from scripts and it does not do an `exit 1` when file variables can't be read, this pull request replaces `log.Printf` calls by `log.Fatalf` calls to do an exit 1 if there are errors when reading the variables.